### PR TITLE
reducing assembly jar size from 30+M -> 800KB

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt.Keys._
 import sbtassembly.AssemblyPlugin.autoImport._
 
-val publishClientAssembly = sys.env.getOrElse("PUBLISH_CLIENT_ASSEMBLY", "true").toBoolean
+val publishClientAssembly = sys.env.getOrElse("PUBLISH_CLIENT_ASSEMBLY", "false").toBoolean
 
 lazy val root = (project in file(".")).
   settings(


### PR DESCRIPTION
@vinothkr Please check this out. 

to build fat jar for service deployment

```
PUBLISH_CLIENT_ASSEMBLY=false sbt assembly
(or)
sbt assembly
```

to build client assembly jar for sonatype publish

```
PUBLISH_CLIENT_ASSEMBLY=true sbt assembly
```
